### PR TITLE
WIP: cleanup stalls on large libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,10 +56,13 @@
     "mocha": "^5.2.0",
     "nyc": "^13.1.0",
     "rimraf": "^2.6.2",
-    "rollup": "^0.68.2",
+    "rollup": "^1.25.1",
     "rollup-plugin-buble": "^0.19.6",
+    "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-jsx": "^1.0.3",
-    "sourcemap-validator": "^1.1.0"
+    "rollup-plugin-node-resolve": "^5.2.0",
+    "sourcemap-validator": "^1.1.0",
+    "zxcvbn": "^4.4.2"
   },
   "peerDependencies": {
     "rollup": ">=0.50.0"

--- a/test/fixtures/issue_17.js
+++ b/test/fixtures/issue_17.js
@@ -1,0 +1,3 @@
+import zxcvbn from 'zxcvbn'
+
+console.log(zxcvbn)

--- a/test/index.js
+++ b/test/index.js
@@ -295,6 +295,23 @@ describe('Issues', function () {
     return Promise.all(result)
   })
 
+  it.only('must handle large libraries', function () {
+    const filename = 'issue_17.js'
+    return rollup({
+      input: concat(filename, 'fixtures'),
+      plugins: [
+        require('rollup-plugin-node-resolve')(),
+        require('rollup-plugin-commonjs')({ 'include': '../node_modules/**' }),
+        cleanup({ sourceMap: false }),
+      ],
+    }).then((bundle) => {
+      return bundle.generate({ format: 'iife' })
+    }).then((result) => {
+      const expected = fs.readFileSync('maps/output.js', 'utf8')
+      expect(result.code).toBe(expected, 'Generated code is incorrect!')
+    })
+  })
+
 })
 
 
@@ -325,7 +342,7 @@ describe('SourceMap support', function () {
         const code = result.code
         const expected = fs.readFileSync('maps/output.js', 'utf8')
 
-        expect(code).toBe(expected, 'Genereted code is incorrect!')
+        expect(code).toBe(expected, 'Generated code is incorrect!')
         expect(result.map).toBeAn(Object).toExist()
         validator(code, JSON.stringify(result.map))
       })


### PR DESCRIPTION
We've experienced an issue with newer versions of rollup-plugin-cleanup appearing to stall on large libraries: Importing [zxcvbn](https://www.npmjs.com/package/zxcvbn) (unfortunately a rather large library; ~800 kB) results in the process never terminating. Disabling rollup-plugin-cleanup fixes that issue.

I've attempted to reproduce the issue in this test: Running `npm test` now no longer terminates.

NB:

* zxcvbn is CommonJS, so I had to add rollup-plugin-commonjs / rollup-plugin-node-resolve.
* A newer, partially incompatible version of Rollup is required for those plugins, so I had to disable other tests (→ `.only`) after updating it.
* Given the nature of this issue and the tweaks above, I'm not sure how to determine which versions of rollup-plugin-cleanup are affected and what the root cause might be ("large libraries" is just a guess); `git bisect` won't help here.