### PR TITLE
fix: add 'mjs' to the default extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ lineEndings     | `unix`   | Type of Line-ending for normalization: "unix", "mac
 sourcemap       | `true`   | Should a sourcemap be generated?
 include         | `''`     | [minimatch](https://github.com/isaacs/minimatch) or array of minimatch patterns for paths to include in the process.
 exclude         | `''`     | minimatch or array of minimatch patterns for paths to exclude of the process.
-extensions      | `['js', 'jsx', 'tag']` | String or array of strings with extensions of files to process.
+extensions      | `['js', 'mjs', 'jsx', 'tag']` | String or array of strings with extensions of files to process.
 
 ## Predefined Comment Filters
 

--- a/src/create-filter.js
+++ b/src/create-filter.js
@@ -18,7 +18,7 @@ const _createFilter = function (opts) {
 
   const filter = createFilter(opts.include, opts.exclude)
 
-  let exts = opts.extensions || ['js', 'jsx']
+  let exts = opts.extensions || ['js', 'mjs', 'jsx']
   if (!Array.isArray(exts)) {
     exts = [exts]
   }


### PR DESCRIPTION
*.mjs is more and more common so use it in the default filter