### PR TITLE
Fix options.extensions being modified by the plugin

### DIFF
--- a/src/create-filter.js
+++ b/src/create-filter.js
@@ -19,7 +19,9 @@ const _createFilter = function (opts) {
   const filter = createFilter(opts.include, opts.exclude)
 
   let exts = opts.extensions || ['js', 'jsx', 'mjs']
-  if (!Array.isArray(exts)) {
+  if (Array.isArray(exts)) {
+    exts = Array.from(exts)
+  } else {
     exts = [exts]
   }
 


### PR DESCRIPTION
Hi,

Your plugin modifies the extensions object passed to its options, which means it cannot be reused across plugins. This means the following sample config fails to properly resolve imports:

```js
const cleanup = require('rollup-plugin-cleanup')
const resolve = require('@rollup/plugin-node-resolve').default

const extensions = ['.js', '.jsx', '.ts', '.tsx', '.json', '.md', '.mdx']

module.exports = {
	// ...
	plugins: [
		resolve({ extensions }),
		cleanup({ extensions }),
	],
}
```

The following PR will ensure extensions are copied instead of written over. It allows Rollup users to share an extension list across plugins.